### PR TITLE
Build .so with collection suffix in soname

### DIFF
--- a/soname.patch
+++ b/soname.patch
@@ -1,0 +1,11 @@
+--- uv.gyp~	2016-08-11 09:29:32.754362526 +0100
++++ uv.gyp	2016-08-11 09:30:15.262533581 +0100
+@@ -171,7 +171,7 @@
+               'link_settings': {
+                 # Must correspond with UV_VERSION_MAJOR and UV_VERSION_MINOR
+                 # in src/version.c
+-                'libraries': [ '-Wl,-soname,libuv.so.0.10' ],
++                'libraries': [ '-Wl,-soname,libuv.so.<(soname_version)' ],
+               },
+             }],
+           ],


### PR DESCRIPTION
Fixes CentOS bug #10606 (https://bugs.centos.org/view.php?id=10606), where libuv from the collection is adding an RPM provides conflicting with libuv from EPEL.

Based on the patch in sig-sclo7-rh-nodejs4-rh.

(nodejs will probably need to rebuilt after this.)
